### PR TITLE
Fixed case-typo in qscintilla.pro

### DIFF
--- a/src/qscintilla.pro
+++ b/src/qscintilla.pro
@@ -286,7 +286,7 @@ SOURCES = \
     SciAccessibility.cpp \
     SciClasses.cpp \
     ScintillaQt.cpp \
-    ../scintilla/lexers/LexA68k.cpp \
+    ../scintilla/lexers/LexA68K.cpp \
     ../scintilla/lexers/LexAPDL.cpp \
     ../scintilla/lexers/LexASY.cpp \
     ../scintilla/lexers/LexAU3.cpp \


### PR DESCRIPTION
The file LexA68K.cpp is referenced with a small "k" in the pro file and therefore cannot be found on case-sensitive OSes.